### PR TITLE
Fixed issue where sign-in page refreshed on invalid credentials

### DIFF
--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -37,13 +37,11 @@ export default function Signup() {
       }, 2000);
     } catch (error: any) {
       if (error.response) {
-        // Log server-side error response
         console.error("Error response from server:", error.response.data);
         Seterrors(
           error.response.data.message || "An error occurred during signup."
         );
       } else {
-        // Log network or other types of errors
         console.error("Network or other error:", error);
         Seterrors("Network error or server is down.");
       }

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -9,7 +9,7 @@ const signupSchema = z.object({
   username: z.string().min(1, "Username required"),
   password: z.string().min(6, "Password must be at least 6 characters"),
 });
-export default function Signup() {
+export default function SignUpPage() {
   const usernameRef = useRef<HTMLInputElement>(null);
   const passwordRef = useRef<HTMLInputElement>(null);
   const [error, Seterrors] = useState("");

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,4 +1,3 @@
-// app/feed/page.tsx
 
 "use server";
 import { auth } from "@/lib/auth";

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -18,19 +18,23 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         const username = credentials.username;
         const password = credentials.password;
 
-        if (!username || !password) {
-          return null;
-        }
         try {
           const user = await prisma.user.findUnique({
             where: {
               username: username,
             },
           });
-          const passwordverify = await verifyPassword(user.password, password);
-          if (user && passwordverify) {
-            return user;
+          if (!user) {
+            return null;
           }
+
+          const passwordverify = await verifyPassword(user.password, password);
+
+          if (!passwordverify) {
+            return null;
+          }
+
+          return user;
         } catch (error) {
           return null;
         }
@@ -41,7 +45,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
   callbacks: {
     async jwt({ token, user }) {
       if (user) {
-        token.id = user.id;
+        token.id = user.id?.toString();
         token.username = user.username;
       }
       return token;
@@ -55,4 +59,5 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
   pages: {
     signIn: "/signin",
   },
+  secret: process.env.AUTH_SECRET,
 });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -12,7 +12,7 @@ export default async function middleware(req: NextRequest) {
   const token = await getToken({ req, secret: process.env.AUTH_SECRET });
 
   if (!token) {
-    return NextResponse.redirect(new URL("/landpage", req.url));
+    return NextResponse.redirect(new URL("/signin", req.url));
   }
 
   return NextResponse.next();


### PR DESCRIPTION
Resolved a bug where submitting incorrect credentials on the sign-in form caused the page to refresh or redirect. The form now correctly stays on the same page and displays an appropriate error message.